### PR TITLE
Gets LinkFiles and RuntimeFiles as a flat set rather then a tree

### DIFF
--- a/src/main/groovy/jaci/gradle/nativedeps/ETNativeDepSet.groovy
+++ b/src/main/groovy/jaci/gradle/nativedeps/ETNativeDepSet.groovy
@@ -49,7 +49,9 @@ public class ETNativeDepSet implements NativeDependencySet {
 
     @Override
     FileCollection getRuntimeFiles() {
-        return dynamicLibs
+        return project.files {
+            return dynamicLibs.files
+        }
     }
 
     boolean appliesTo(Flavor flav, BuildType btype, NativePlatform plat) {


### PR DESCRIPTION
As a tree, the install tasks do not properly work. Dependency sets
expect these files as a flat set of files to work properly