### PR TITLE
Add way to extend targets and artifacts in deploy block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2018.09.16" // YYYY.MM.DD(revision)
+version = "2018.09.21" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/deploy/DeployExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/DeployExtension.groovy
@@ -10,6 +10,7 @@ import jaci.gradle.deploy.target.RemoteTarget
 import jaci.gradle.deploy.target.TargetsExtension
 import jaci.gradle.deploy.target.discovery.TargetDiscoveryTask
 import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskCollection
 
@@ -27,9 +28,9 @@ class DeployExtension {
     @Inject
     DeployExtension(Project project) {
         this.project = project
-        targets = new TargetsExtension(project)
-        artifacts = new ArtifactsExtension(project)
-        cache = new CacheExtension(project)
+        targets = ((ExtensionAware)this).extensions.create('targets', TargetsExtension, project)
+        artifacts = ((ExtensionAware)this).extensions.create('artifacts', ArtifactsExtension, project)
+        cache = ((ExtensionAware)this).extensions.create('cache', CacheExtension, project)
 
         this.targets.all { RemoteTarget target ->
             project.tasks.register("discover${target.name.capitalize()}".toString(), TargetDiscoveryTask) { TargetDiscoveryTask task ->


### PR DESCRIPTION
Super useful for cleaning up GradleRIO

On the creating extensions side, looks like
```
project.extensions.getByType(DeployExtension).artifacts.extensions.frcJavaArtifact = { String s, Closure c =>
}
```