### PR TITLE
Only resolve each configuration once during a run.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2018.12.06" // YYYY.MM.DD(revision)
+version = "2018.12.11" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/files/FileTreeSupplier.groovy
+++ b/src/main/groovy/jaci/gradle/files/FileTreeSupplier.groovy
@@ -1,0 +1,28 @@
+package jaci.gradle.files
+
+import groovy.transform.CompileStatic
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.file.FileTree
+
+import java.util.function.Supplier
+import java.util.function.Function
+
+@CompileStatic
+class FileTreeSupplier implements Supplier<FileTree> {
+  private Set<ResolvedArtifact> resolvedArtifacts
+  private Function<Set<ResolvedArtifact>, FileTree> resolveFunc
+  private Configuration cfg
+
+  FileTreeSupplier(Configuration cfg, Function<Set<ResolvedArtifact>, FileTree> resolveFunc) {
+    this.cfg = cfg
+    this.resolveFunc = resolveFunc
+  }
+
+  FileTree get() {
+    if (resolvedArtifacts == null) {
+      resolvedArtifacts = cfg.resolvedConfiguration.resolvedArtifacts
+    }
+    return resolveFunc.apply(resolvedArtifacts)
+  }
+}


### PR DESCRIPTION
Shouldn't be an issue, but Gradle 5 throws a deprecation warning when resolving during the install task.

This makes it so each configuration gets resolved only once.

We don't need to merge this, but it will remove the deprecation warning.