### PR TITLE
Support no libraries linked to native library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2018.12.14" // YYYY.MM.DD(revision)
+version = "2018.12.18" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/deploy/artifact/BinaryLibraryArtifact.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/artifact/BinaryLibraryArtifact.groovy
@@ -17,7 +17,10 @@ class BinaryLibraryArtifact extends FileCollectionArtifact {
 
     @Override
     void deploy(DeployContext ctx) {
-        files.set(binary.libs.collect { it.getRuntimeFiles() }.inject { a,b -> a + b } as FileCollection)
-        super.deploy(ctx)
+        def libs = binary.libs.collect { it.getRuntimeFiles() }
+        if (libs.size() != 0 ) {
+            files.set(libs.inject { a,b -> a + b } as FileCollection)
+            super.deploy(ctx)
+        }
     }
 }


### PR DESCRIPTION
Currently, if the deployLibraries flag is set and the library has no runtimeLibs, it will fail.

Closes #34