### PR TITLE
Explicitly return target rather then def from TargetsExtension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2018.12.14" // YYYY.MM.DD(revision)
+version = "2018.12.18" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/deploy/target/TargetsExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/target/TargetsExtension.groovy
@@ -17,14 +17,15 @@ class TargetsExtension extends DefaultNamedDomainObjectSet<RemoteTarget> impleme
         this.project = project
     }
 
-    def target(String name, Class<? extends RemoteTarget> type, final Closure config) {
+    RemoteTarget target(String name, Class<? extends RemoteTarget> type, final Closure config) {
         def target = type.newInstance(name, project)
         project.configure(target, config)
         this << (target)
+        return target
     }
 
-    def target(String name, final Closure config) {
-        target(name, RemoteTarget, config)
+    RemoteTarget target(String name, final Closure config) {
+        return target(name, RemoteTarget, config)
     }
 
     @Override


### PR DESCRIPTION
Matches artifacts, and makes the using API cleaner

Closes #33