### PR TITLE
Move the useLibrary declaration from a root extension to the embedded…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 EmbeddedTools
 ====
-Compile and Deploy for Embedded Targets in both Java and C++. 
+Compile and Deploy for Embedded Targets in both Java and C++.
 
 EmbeddedTools adds compiler and library rules to make writing native software easier.
 For all projects, you can define deployment targets and artifacts. The deploy process works over SSH/SFTP and
 is extremely quick.
 
-Commands:   
-`gradlew deploy` will deploy all artifacts  
+Commands:
+`gradlew deploy` will deploy all artifacts
 `gradlew deploy<artifact name><target name>` will deploy only the specified artifact to the specified target
 
-Properties:    
-`gradlew deploy -Pdeploy-dirty` will skip the cache check and force redeployment of all files  
-`gradlew deploy -Pdeploy-dry` will do a 'dry run' (will not connect or deploy to target, instead only printing to console)  
+Properties:
+`gradlew deploy -Pdeploy-dirty` will skip the cache check and force redeployment of all files
+`gradlew deploy -Pdeploy-dry` will do a 'dry run' (will not connect or deploy to target, instead only printing to console)
 
 ## Installing plugin
 Include the following in your `build.gradle`
@@ -24,7 +24,7 @@ plugins {
 
 See [https://plugins.gradle.org/plugin/jaci.gradle.EmbeddedTools](https://plugins.gradle.org/plugin/jaci.gradle.EmbeddedTools) for the latest version
 
-## Spec 
+## Spec
 
 ```gradle
 import jaci.gradle.toolchains.*
@@ -87,7 +87,7 @@ deploy {
             // Output will be stored in 'result' after execution
         }
 
-        // JavaArtifact inherits from FileArtifact 
+        // JavaArtifact inherits from FileArtifact
         javaArtifact('myJavaArtifact') {
             jar = 'jar'                         // The jar (or Jar task) to deploy. Default: 'jar'
             // Note: This artifact will automatically depend on the jar build task
@@ -97,7 +97,7 @@ deploy {
         nativeArtifact('myNativeArtifact') {
             component = 'my_program'            // Required. The name of the native component (model.components {}) to deploy.
             targetPlatform = 'desktop'          // The name of the native platform (model.platforms {}) to deploy.
-            
+
             // Note: This artifact will automatically depend on the native component link task
         }
 
@@ -130,7 +130,7 @@ model {
             sharedMatchers << '**/*.so'                     // Shared Libraries to be linked at compile time
             dynamicMatchers << '**/*.so'                    // Libraries that aren't linked, but still needed at runtime.
             systemLibs << 'm'                               // System libs to load with -l (provided by toolchain)
-            
+
             maven = "some.maven.package:mylib:1.0.0@zip"    // Load from maven. Must be a zip or zip-compatible (like a jar)
             file = project.file("mylib.zip")                // Load from filesystem instead. Can be given a zip or a directory.
         }
@@ -143,7 +143,7 @@ model {
 
     components {
         my_program(NativeExecutableSpec) {
-            useLibrary(it, "myComboLib")
+            embeddedTools.useLibrary(it, "myComboLib")
         }
     }
 }

--- a/_localtest/build.gradle
+++ b/_localtest/build.gradle
@@ -109,7 +109,7 @@ model {
             sources.cpp {
                 source.srcDirs "src_c"
             }
-            useLibrary(it, "wpi_headers")
+            embeddedTools.useLibrary(it, "wpi_headers")
         }
     }
 }
@@ -226,7 +226,7 @@ buildScan {
 //                source.srcDirs "src_c"
 //            }
 //
-//            useLibrary(it, "wpilib")
+//            embeddedTools.useLibrary(it, "wpilib")
 //        }
 //    }
 //}

--- a/src/main/groovy/jaci/gradle/EmbeddedTools.groovy
+++ b/src/main/groovy/jaci/gradle/EmbeddedTools.groovy
@@ -18,6 +18,7 @@ class EmbeddedTools implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.extensions.create('em_projectwrapper', ProjectWrapper, project)
+        project.extensions.create('embeddedTools', EmbeddedToolsExtension, project)
 
         ETLoggerFactory.INSTANCE.addColorOutput(project)
 

--- a/src/main/groovy/jaci/gradle/EmbeddedToolsExtension.groovy
+++ b/src/main/groovy/jaci/gradle/EmbeddedToolsExtension.groovy
@@ -1,0 +1,46 @@
+package jaci.gradle
+
+import javax.inject.Inject
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.Project
+import org.gradle.nativeplatform.NativeBinarySpec
+import org.gradle.platform.base.VariantComponentSpec
+
+import jaci.gradle.nativedeps.DelegatedDependencySet
+import jaci.gradle.nativedeps.DependencySpecExtension
+
+@CompileStatic
+class EmbeddedToolsExtension {
+    private DependencySpecExtension dse = null
+    private Project project
+
+    @Inject
+    EmbeddedToolsExtension(Project project) {
+        this.project = project
+    }
+
+    void useLibrary(VariantComponentSpec component, boolean skipOnUnknown, String... libraries) {
+        component.binaries.withType(NativeBinarySpec).all { binary ->
+            useLibrary(binary, skipOnUnknown, libraries)
+        }
+    }
+
+    void useLibrary(VariantComponentSpec component, String... libraries) {
+        useLibrary(component, false, libraries)
+    }
+
+    void useLibrary(NativeBinarySpec binary, boolean skipOnUnknown, String... libraries) {
+        if (dse == null) {
+            dse = project.extensions.getByType(DependencySpecExtension)
+        }
+        libraries.each { library ->
+            binary.lib(new DelegatedDependencySet(library, binary, dse, skipOnUnknown))
+        }
+    }
+
+    void useLibrary(NativeBinarySpec binary, String... libraries) {
+        useLibrary(binary, false, libraries)
+    }
+}

--- a/src/main/groovy/jaci/gradle/nativedeps/NativeDepsPlugin.groovy
+++ b/src/main/groovy/jaci/gradle/nativedeps/NativeDepsPlugin.groovy
@@ -32,34 +32,6 @@ class NativeDepsPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         DependencySpecExtension dse = project.extensions.create("ETDependencySpecs", DependencySpecExtension, project)
-
-        project.extensions.add("useLibrary", { Object closureArg, String... names ->
-            if (closureArg in VariantComponentSpec) {
-                VariantComponentSpec component = (VariantComponentSpec)closureArg
-                component.binaries.withType(NativeBinarySpec).all { NativeBinarySpec bin ->
-                    Set<DelegatedDependencySet> dds = names.collect { String name ->
-                        new DelegatedDependencySet(name, bin, dse)
-                    } as Set
-
-                    dds.each { DelegatedDependencySet set ->
-                        bin.lib(set)
-                    }
-                }
-            } else if (closureArg in NativeBinarySpec) {
-                NativeBinarySpec bin = (NativeBinarySpec) closureArg
-                Set<DelegatedDependencySet> dds = names.collect { String name ->
-                    new DelegatedDependencySet(name, bin, dse)
-                } as Set
-
-                dds.each { DelegatedDependencySet set ->
-                    bin.lib(set)
-                }
-            } else if (closureArg in LanguageSourceSet) {
-                throw new GradleException('The useLibrary command needs to be placed directly in the component. Move it outside of the sources declaration.')
-            } else {
-                throw new GradleException('Unknown type for useLibrary target. You put this declaration in a weird place...')
-            }
-        })
     }
 
     static class NativeDepsRules extends RuleSource {


### PR DESCRIPTION
…Tools extension

By doing this, they are now type safe. This makes them easier to use from Java, and to extend on if necessary.
It also avoids poluting the root extension space. Its a slight breaking change, but in gradlerio we can actually just add duplicates on the wpi extension.

That would make in C++ the use library change to wpi.useLibrary(it, ...) which is much cleaner, and intellisense would work