### PR TITLE
Add IsExplicit property on Artifact

### DIFF
--- a/src/main/groovy/jaci/gradle/deploy/DeployExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/DeployExtension.groovy
@@ -63,7 +63,7 @@ class DeployExtension {
         def deployTask = project.tasks.register("deploy") { Task task ->
             task.group = "EmbeddedTools"
             task.description = "Deploy all artifacts on all targets"
-            task.dependsOn(project.tasks.withType(ArtifactDeployTask))
+            task.dependsOn({ project.tasks.withType(ArtifactDeployTask).matching { ArtifactDeployTask t -> !t.artifact.explicit }} as Callable<TaskCollection> )
 //            project.tasks.withType(ArtifactDeployTask).all { ArtifactDeployTask task2 ->
 //                task.dependsOn(task2)
 //            }

--- a/src/main/groovy/jaci/gradle/deploy/artifact/AbstractArtifact.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/artifact/AbstractArtifact.groovy
@@ -21,6 +21,7 @@ abstract class AbstractArtifact implements Artifact {
     private DomainObjectSet<Object> targets = new DefaultDomainObjectSet<>(Object)
 
     private disabled = false
+    private explicit = false
 
     @Inject
     AbstractArtifact(String name, Project project) {
@@ -88,6 +89,16 @@ abstract class AbstractArtifact implements Artifact {
         return disabled ? false :
                 onlyIf == null ? true :
                         (onlyIf.test(ctx) || ctx?.deployLocation?.target?.isDry())
+    }
+
+    @Override
+    boolean isExplicit() {
+        return this.explicit
+    }
+
+    @Override
+    void setExplicit(boolean isExplicit) {
+        this.explicit = isExplicit
     }
 
     @Override

--- a/src/main/groovy/jaci/gradle/deploy/artifact/Artifact.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/artifact/Artifact.groovy
@@ -34,4 +34,7 @@ interface Artifact extends Named {
     void setDisabled()
 
     void deploy(DeployContext context)
+
+    boolean isExplicit()
+    void setExplicit(boolean explicit)
 }

--- a/src/test/groovy/jaci/gradle/deploy/artifact/DeployDependenciesTest.groovy
+++ b/src/test/groovy/jaci/gradle/deploy/artifact/DeployDependenciesTest.groovy
@@ -1,0 +1,105 @@
+package jaci.gradle.deploy.artifact
+
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class DeployDependenciesTest extends Specification {
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def "Deploy Properly Depends"() {
+        given:
+        buildFile << """
+plugins {
+    id 'jaci.gradle.EmbeddedTools'
+}
+
+deploy {
+    targets {
+        target('test') {
+            directory = '/home/lvuser'
+            locations {
+                ssh {
+                    address = 'does.not.exist'
+                    user = 'no'
+                }
+            }
+        }
+    }
+    artifacts {
+        fileArtifact('myFileArtifact') {
+            file = project.file('build.gradle')
+            targets << 'test'
+        }
+        commandArtifact('myCommandArtifact') {
+            command = 'uname -a'
+            targets << 'test'
+        }
+    }
+}
+"""
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('deploy', '--stacktrace', '-Pdeploy-dry')
+            .withPluginClasspath()
+            .build()
+        then:
+            result.task(':discoverTest').outcome == SUCCESS
+            result.task(':deployMyCommandArtifactTest').outcome == SUCCESS
+            result.task(':deployMyFileArtifactTest').outcome == SUCCESS
+            result.task(':deploy').outcome == SUCCESS
+    }
+
+    def "Deploy Explicit Skips"() {
+        given:
+        buildFile << """
+plugins {
+    id 'jaci.gradle.EmbeddedTools'
+}
+
+deploy {
+    targets {
+        target('test') {
+            directory = '/home/lvuser'
+            locations {
+                ssh {
+                    address = 'does.not.exist'
+                    user = 'no'
+                }
+            }
+        }
+    }
+    artifacts {
+        fileArtifact('myFileArtifact') {
+            file = project.file('build.gradle')
+            targets << 'test'
+        }
+        commandArtifact('myCommandArtifact') {
+            command = 'uname -a'
+            targets << 'test'
+            explicit = true
+        }
+    }
+}
+"""
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('deploy', '--stacktrace', '-Pdeploy-dry')
+            .withPluginClasspath()
+            .build()
+        then:
+            result.task(':discoverTest').outcome == SUCCESS
+            result.task(':deployMyCommandArtifactTest') == null
+            result.task(':deployMyFileArtifactTest').outcome == SUCCESS
+            result.task(':deploy').outcome == SUCCESS
+    }
+}


### PR DESCRIPTION
This way an artifact can be ran exclusively by triggering it, rather then being implicitly ran when deploy runs

Closes #47 

Also adds a test to ensure this behavior continues to work.