### PR TITLE
Fix single missing toolchain print

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2019.5.26" // YYYY.MM.DD(revision)
+version = "2019.6.16" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -78,6 +78,6 @@ gradlePlugin {
 }
 
 wrapper {
-    gradleVersion = '5.4'
+    gradleVersion = '5.4.1'
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The logic was backwards before, and after thinking and testing, the flag in ET should just skip all binary prints.
In the TC plugin, we had an additional print done by the GccToolChain. That should be the one set to single print, and this one should be completely disableable, as the other one makes much more sense to an end user.

Replaces #52 