### PR TITLE
 Use ObjectFactory to create extensions, rather then an extension aware cast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2019.6.16" // YYYY.MM.DD(revision)
+version = "2019.8.5" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/deploy/DeployExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/DeployExtension.groovy
@@ -15,7 +15,7 @@ import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskCollection
 
 import javax.inject.Inject
@@ -30,11 +30,11 @@ class DeployExtension {
     Project project
 
     @Inject
-    DeployExtension(Project project) {
+    DeployExtension(Project project, ObjectFactory objects) {
         this.project = project
-        targets = ((ExtensionAware)this).extensions.create('targets', TargetsExtension, project)
-        artifacts = ((ExtensionAware)this).extensions.create('artifacts', ArtifactsExtension, project)
-        cache = ((ExtensionAware)this).extensions.create('cache', CacheExtension, project)
+        targets = objects.newInstance(TargetsExtension, project)
+        artifacts = objects.newInstance(ArtifactsExtension, project)
+        cache = objects.newInstance(CacheExtension, project)
 
         this.targets.all { RemoteTarget target ->
             project.tasks.register("discover${target.name.capitalize()}".toString(), TargetDiscoveryTask) { TargetDiscoveryTask task ->

--- a/src/main/groovy/jaci/gradle/deploy/artifact/ArtifactsExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/artifact/ArtifactsExtension.groovy
@@ -8,12 +8,15 @@ import org.gradle.api.Project
 import org.gradle.api.internal.DefaultNamedDomainObjectSet
 import org.gradle.internal.reflect.DirectInstantiator
 
+import javax.inject.Inject
+
 // DefaultNamedDomainObjectSet applies the withType, matching, all and other methods
 // that are incredibly useful
 @CompileStatic
 class ArtifactsExtension extends DefaultNamedDomainObjectSet<Artifact> implements Resolver<Artifact> {
     final Project project
 
+    @Inject
     ArtifactsExtension(Project project) {
         super(Artifact.class, DirectInstantiator.INSTANCE)
         this.project = project

--- a/src/main/groovy/jaci/gradle/deploy/cache/CacheExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/cache/CacheExtension.groovy
@@ -7,11 +7,14 @@ import org.gradle.api.Project
 import org.gradle.api.internal.DefaultNamedDomainObjectSet
 import org.gradle.internal.reflect.DirectInstantiator
 
+import javax.inject.Inject
+
 @CompileStatic
 class CacheExtension extends DefaultNamedDomainObjectSet<CacheMethod> implements Resolver<CacheMethod> {
 
     final Project project
 
+    @Inject
     CacheExtension(Project project) {
         super(CacheMethod.class, DirectInstantiator.INSTANCE)
         this.project = project

--- a/src/main/groovy/jaci/gradle/deploy/target/RemoteTarget.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/target/RemoteTarget.groovy
@@ -12,7 +12,6 @@ import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Named
 import org.gradle.api.Project
 import java.util.function.Function
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.TaskCollection
 
 import javax.inject.Inject

--- a/src/main/groovy/jaci/gradle/deploy/target/TargetsExtension.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/target/TargetsExtension.groovy
@@ -7,12 +7,15 @@ import org.gradle.api.Project
 import org.gradle.api.internal.DefaultNamedDomainObjectSet
 import org.gradle.internal.reflect.DirectInstantiator
 
+import javax.inject.Inject
+
 // DefaultNamedDomainObjectSet applies the withType, matching, all and other methods
 // that are incredibly useful
 @CompileStatic
 class TargetsExtension extends DefaultNamedDomainObjectSet<RemoteTarget> implements Resolver<RemoteTarget> {
     final Project project
 
+    @Inject
     TargetsExtension(Project project) {
         super(RemoteTarget, DirectInstantiator.INSTANCE)
         this.project = project


### PR DESCRIPTION
Cleaner and much more maintainable, plus easier to use from dependent projects