### PR TITLE
mkdir the parent file when deploying each file 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2019.10.1" // YYYY.MM.DD(revision)
+version = "2019.10.1-1" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2019.6.16" // YYYY.MM.DD(revision)
+version = "2019.10.1" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/deploy/sessions/SshSessionController.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/sessions/SshSessionController.groovy
@@ -64,6 +64,12 @@ class SshSessionController extends AbstractSessionController implements IPSessio
         sftp.connect()
         try {
             files.each { String dst, File src ->
+                try {
+                    def mkdir = new File(dst).parentFile.toString().replace('\\', '/')
+                    sftp.mkdir(mkdir)
+                } catch (Exception ex) {
+                    // Do nothing on catch
+                }
                 sftp.put(src.absolutePath, dst)
             }
         } finally {

--- a/src/main/groovy/jaci/gradle/deploy/target/RemoteTarget.groovy
+++ b/src/main/groovy/jaci/gradle/deploy/target/RemoteTarget.groovy
@@ -79,5 +79,6 @@ class RemoteTarget implements Named {
             log.debug("OnlyIf check failed! Not connecting...")
             return false
         }
+        return true
     }
 }


### PR DESCRIPTION
@JacisNonsense can you think of any issues with this. Its working, I just want to make sure I'm not missing any edge cases.

I need this in GradleRIO to implement the java separate classpath files, as I have to deploy them to individual folder. If I do this at the higher level, my only option is to deploy each file individually, which can't sure MD5 executions, and causes some fairly bad speed regressions.